### PR TITLE
Duplicates messages in MediatR Notification Handlers

### DIFF
--- a/src/Modules/Forms/YourCorporation.Modules.Forms.Api/IntegrationEventsHandlers/Handlers/WorkLocationCreatedHandler.cs
+++ b/src/Modules/Forms/YourCorporation.Modules.Forms.Api/IntegrationEventsHandlers/Handlers/WorkLocationCreatedHandler.cs
@@ -19,13 +19,6 @@ namespace YourCorporation.Modules.Forms.Api.IntegrationEventsHandlers.Handlers
 
         public async Task Handle(WorkLocationCreated notification, CancellationToken cancellationToken)
         {
-            var existingWorkLocation = await _workLocationRepository.GetAsync(notification.Id);
-            if (existingWorkLocation is not null)
-            {
-                _logger.LogInformation($"Work location with id '{notification.Id}' already exists.");
-                return;
-            }
-
             var workLocation = new WorkLocation(notification.Id, notification.Name, notification.Code);
 
             await _workLocationRepository.AddAsync(workLocation);

--- a/src/Modules/Recruitment/YourCorporation.Modules.Recruitment.Application/IntegrationEventHandlers/Handlers/WorkLocationCreatedHandler.cs
+++ b/src/Modules/Recruitment/YourCorporation.Modules.Recruitment.Application/IntegrationEventHandlers/Handlers/WorkLocationCreatedHandler.cs
@@ -18,13 +18,6 @@ namespace YourCorporation.Modules.Recruitment.Application.IntegrationEventHandle
 
         public async Task Handle(WorkLocationCreated notification, CancellationToken cancellationToken)
         {
-            var existingWorkLocation = await _workLocationRepository.GetAsync(notification.Id);
-            if (existingWorkLocation is not null)
-            {
-                _logger.LogInformation($"Work location with id '{notification.Id}' already exists.");
-                return;
-            }
-
             var workLocation = new WorkLocation(new WorkLocationId(notification.Id), notification.Name, notification.Code);
 
             _workLocationRepository.Add(workLocation);

--- a/src/Shared/YourCorporation.Shared.Abstractions/Messaging/Inbox/IInboxNotificationPublisher.cs
+++ b/src/Shared/YourCorporation.Shared.Abstractions/Messaging/Inbox/IInboxNotificationPublisher.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace YourCorporation.Shared.Abstractions.Messaging.Inbox
+{
+    public interface IInboxNotificationPublisher 
+    {
+        Task Publish<TNotification>(TNotification notification, string moduleName) where TNotification : IMessage;
+    }
+}

--- a/src/Shared/YourCorporation.Shared.Infrastructure/MediatR/Extensions.cs
+++ b/src/Shared/YourCorporation.Shared.Infrastructure/MediatR/Extensions.cs
@@ -1,6 +1,8 @@
 ﻿using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using YourCorporation.Shared.Abstractions.MediatR.Behaviors;
+using YourCorporation.Shared.Abstractions.Messaging.Inbox;
+using YourCorporation.Shared.Infrastructure.Messaging.Inbox;
 
 namespace YourCorporation.Shared.Infrastructure.MediatR
 {
@@ -8,6 +10,7 @@ namespace YourCorporation.Shared.Infrastructure.MediatR
     {
         public static IServiceCollection AddBehaviors(this IServiceCollection services)
         {
+            services.AddScoped<IInboxNotificationPublisher, InboxNotificationPublisher>();
             services.AddScoped(typeof(IPipelineBehavior<,>), typeof(ValidationPipelineBehavior<,>));
 
             return services;

--- a/src/Shared/YourCorporation.Shared.Infrastructure/Messaging/Inbox/Inbox.cs
+++ b/src/Shared/YourCorporation.Shared.Infrastructure/Messaging/Inbox/Inbox.cs
@@ -19,7 +19,7 @@ namespace YourCorporation.Shared.Infrastructure.Messaging.Inbox
         private readonly TimeProvider _timeProvider;
         private readonly ILogger<Inbox<T>> _logger;
         private readonly IMessageContextRegistry _messageContextRegistry;
-        private readonly IPublisher _publisher;
+        private readonly IInboxNotificationPublisher _publisher;
 
         public bool Enabled { get; }
 
@@ -29,7 +29,7 @@ namespace YourCorporation.Shared.Infrastructure.Messaging.Inbox
             ILogger<Inbox<T>> logger,
             IOptions<OutboxOptions> options,
             IMessageContextRegistry messageContextRegistry,
-            IPublisher publisher)
+            IInboxNotificationPublisher publisher)
         {
             _dbContext = dbContext;
             _inboxMessages = _dbContext.Set<InboxMessage>();
@@ -126,7 +126,7 @@ namespace YourCorporation.Shared.Infrastructure.Messaging.Inbox
 
                 try
                 {
-                    await _publisher.Publish(message);
+                    await _publisher.Publish(message, moduleName);
                 }
                 catch (Exception exception)
                 {

--- a/src/Shared/YourCorporation.Shared.Infrastructure/Messaging/Inbox/InboxNotificationPublisher.cs
+++ b/src/Shared/YourCorporation.Shared.Infrastructure/Messaging/Inbox/InboxNotificationPublisher.cs
@@ -1,0 +1,57 @@
+﻿using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using YourCorporation.Shared.Abstractions.Messaging;
+using YourCorporation.Shared.Abstractions.Messaging.Inbox;
+using System.Reflection;
+using YourCorporation.Shared.Infrastructure.Persistence;
+
+namespace YourCorporation.Shared.Infrastructure.Messaging.Inbox
+{
+    internal class InboxNotificationPublisher : IInboxNotificationPublisher
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        public InboxNotificationPublisher(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        public async Task Publish<TNotification>(TNotification notification, string moduleName) where TNotification : IMessage
+        {
+            Type notificationType = notification.GetType();
+            Type handlerType = typeof(INotificationHandler<>).MakeGenericType(notificationType);
+            var handlers = _serviceProvider.GetServices(handlerType);
+
+            // All messages are published using NotificationHandlers and changes are saved to database using UnitOfWorkNotificationHandlerDecorator, which contains _innerHandler
+            // that's why is necessary to retrieve _innerHandler and on this specific innerHandler check if this is the module which should get this notification
+            foreach (var handler in handlers)
+            {
+                var innerHandler = GetInnerHandler(handler);
+                if (IsHandlerInModule(innerHandler, moduleName))
+                {
+                    MethodInfo handleMethod = handlerType.GetMethod("Handle");
+                    await (Task)handleMethod.Invoke(handler, [notification, CancellationToken.None]);
+                }
+            }
+        }
+
+        private object GetInnerHandler(object handler)
+        {
+            var type = handler.GetType();
+            var field = type.GetField("_innerHandler", BindingFlags.NonPublic | BindingFlags.Instance);
+            if (field != null)
+            {
+                return field.GetValue(handler);
+            }
+            return handler;
+        }
+
+        private bool IsHandlerInModule(object handler, string moduleName)
+        {
+            var handlerNamespace = handler.GetType().Namespace;
+            return handlerNamespace != null && 
+                   handlerNamespace.Contains($".Modules.{moduleName}.", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}
+


### PR DESCRIPTION
Solve the problem of receiving duplicate messages by if a message implementing IIntegrationEvent had handlers in different modules. This was because MediatR always distributes the message to all listening objects implementing INotificationHandler<Type>, where we need it to go only to the specific module for which the inbox message is currently being processed